### PR TITLE
16 startup sync provider ahead

### DIFF
--- a/src/sync/sync.ts
+++ b/src/sync/sync.ts
@@ -339,16 +339,6 @@ export class Sync {
 			throw new Error("Sync Error: fileMap not initialized");
 		}
 
-		/*
-		 * 1. convert remote path to client path
-		 * 2. getClientFolderOrFile
-		 * 3. delete from vault
-		 * 4. If folder:
-		 *	a. Delete from fileMap (Maybe this is not needed - can just error on folder lookup)
-		 *
-		 *
-		 */
-
 		const sanitizedRemotePath = this.sanitizeRemotePath({
 			vaultRoot: this.settings.cloudVaultPath,
 			filePath: args.remoteFileMetadata.path_lower!,
@@ -366,27 +356,10 @@ export class Sync {
 				this.obsidianApp.vault.getFolderByPath(sanitizedClientPath);
 		}
 
-		console.log("folderOrFile:", folderOrFile);
-		//if (!folderOrFile) return;
+		if (!folderOrFile) return;
 
-		if (!folderOrFile) {
-			console.log("null folderOrFile");
-			return;
-		}
 		await this.obsidianApp.vault.delete(folderOrFile, true);
 		this.fileMap.delete(sanitizedRemotePath);
-		/*
-		if (args.clientFileMetadata) return;
-		const clientFile = this.obsidianApp.vault.getFileByPath(
-			args.clientFileMetadata.path,
-		);
-
-		console.log("GET - clientFile:", clientFile);
-
-		if (!clientFile) return;
-		this.obsidianApp.vault.delete(clientFile);
-		this.fileMap.delete(args.clientFileMetadata.remotePath);
-		*/
 	}
 
 	reconcileClientAhead(args: { clientFile: TAbstractFile }): Promise<void>;


### PR DESCRIPTION
## Description
Handle application out of sync from having the remote provider ahead
Handles:
- Folder Created
- Folder Renamed
- Folder Moved
- Folder Deleted

- File Created
- File Renamed
- File Updated
- File Moved
- File Deleted

This PR include a refactor that extracts the `syncFiles` function to be used in `syncRemoteFiles` and `syncRemoteFilesLongPoll`

## Manual Testing
All actions done on server and tested on startup and while running
- [x] Folder Created
- [x] Folder Renamed
- [x] Folder Moved
- [x] Folder Deleted
- [x] File Created @ root
- [x] File Created in sub folder
- [x] File Renamed
- [x] File Moved
- [x] File Updated
- [x] File Deleted
